### PR TITLE
メモリ参照情報の追加

### DIFF
--- a/exedit.hpp
+++ b/exedit.hpp
@@ -20,3 +20,5 @@
 #include <exedit/SubFilterProcInfo.hpp>
 #include <exedit/susie.hpp>
 #include <exedit/undo.hpp>
+#include <exedit/variables_core.hpp>
+#include <exedit/variables.hpp>

--- a/exedit/variables.hpp
+++ b/exedit/variables.hpp
@@ -1,0 +1,166 @@
+#pragma once
+#include <exedit/variables_core.hpp>
+#include <exedit/Filter.hpp>
+#include <exedit/scene.hpp>
+#include <exedit/layer.hpp>
+#include <exedit/Object.hpp>
+#include <exedit/CameraZBuffer.hpp>
+
+#define _OFFSET(exedit_version) static inline constexpr unsigned int offset##exedit_version
+
+namespace ExEdit {
+	namespace Variables {
+
+		struct staticFilterTable : Variable<Filter*, true> {
+			_OFFSET(092) = 0x0A3E28;
+			_OFFSET(093rc1) = 0x0C0A78;
+		};
+
+		struct aliasNameBuffer : Variable<char, true> {
+			_OFFSET(092) = 0x135C70;
+			_OFFSET(093rc1) = 0x18FDB8;
+		};
+
+		struct objectDialog {
+			struct commandTarget : Variable<int> {
+				_OFFSET(092) = 0x14965C;
+				_OFFSET(093rc1) = 0x25E97C;
+			};
+
+			struct filterStatus : Variable<unsigned char, true> {
+				_OFFSET(092) = 0x158D38;
+				_OFFSET(093rc1) = 0x1C1310;
+			};
+
+			struct objectIndex : Variable<int> {
+				_OFFSET(092) = 0x177A10;
+				_OFFSET(093rc1) = 0x1051C8;
+			};
+		};
+
+		struct sceneSetting : Variable<SceneSetting, true> {
+			_OFFSET(092) = 0x177A50;
+			_OFFSET(093rc1) = 0x1051D0;
+		};
+
+		struct loadedFilterTable : Variable<Filter*, true> {
+			_OFFSET(092) = 0x187C98;
+			_OFFSET(093rc1) = 0x106490;
+		};
+
+		struct layerSetting : Variable<LayerSetting, true> {
+			_OFFSET(092) = 0x188498;
+			_OFFSET(093rc1) = 0x0FB580;
+		};
+
+		struct sceneDisplaying : Variable<int> {
+			_OFFSET(092) = 0x1A5310;
+			_OFFSET(093rc1) = 0x0EC098;
+		};
+
+		struct textBuffer : Variable<wchar_t, true> {
+			_OFFSET(092) = 0x1A6BD0;
+			_OFFSET(093rc1) = 0x1158B8;
+		};
+
+		struct trackBarScript {
+			struct processingTrackBarIndex : Variable<int> {
+				_OFFSET(092) = 0x1B21F4;
+				_OFFSET(093rc1) = 0x1CD824;
+			};
+
+			struct processingObjectIndex : Variable<int> {
+				_OFFSET(092) = 0x1B2B04;
+				_OFFSET(093rc1) = 0x1CD59C;
+			};
+		};
+
+		struct scriptProcessingFilter : Variable<Filter*> {
+			_OFFSET(092) = 0x1B2B10;
+			_OFFSET(093rc1) = 0x1CD6AC;
+		};
+
+#ifdef lua_h
+		struct luaState : Variable<lua_State, true> {
+			_OFFSET(092) = 0x1BACA8;
+			_OFFSET(093rc1) = 0x1CD560;
+		};
+#endif
+
+		struct objectTable : Variable<Object[]> {
+			_OFFSET(092) = 0x1E0FA4;
+			_OFFSET(093rc1) = 0x12BA58;
+
+			struct length : Variable<int> {
+				_OFFSET(092) = 0x146250;
+			};
+
+			struct size : Variable<int> {
+				_OFFSET(092) = 0x1E0FA0;
+				_OFFSET(093rc1) = 0x129A4C;
+			};
+		};
+
+		struct sortedObjectTable : Variable<Object*, true> {
+			_OFFSET(092) = 0x168FA8;
+			_OFFSET(093rc1) = 0x1B2560;
+
+			using length = objectTable::length;
+
+			struct layerIndexBegin : Variable<int> {
+				_OFFSET(092) = 0x149670;
+				_OFFSET(093rc1) = 0x1A0360;
+			};
+
+			struct layerIndexEnd : Variable<int> {
+				_OFFSET(092) = 0x135AC8;
+				_OFFSET(093rc1) = 0x1A0628;
+			};
+		};
+
+		struct objectExtraData : Variable<void*> {
+			_OFFSET(092) = 0x1E0FA8;
+			_OFFSET(093rc1) = 0x125A2C;
+
+			struct size : Variable<int> {
+				_OFFSET(092) = 0x1E0F9C;
+				_OFFSET(093rc1) = 0x12BA54;
+			};
+		};
+
+		struct cameraZBuffer : Variable<ZBufferElm[]> {
+			_OFFSET(092) = 0x1EC7AC;
+			_OFFSET(093rc1) = 0x239658;
+		};
+
+		struct undo {
+			struct buffer : Variable<void*> {
+				_OFFSET(092) = 0x244E0C;
+				_OFFSET(093rc1) = 0x248D00;
+
+				struct size : Variable<unsigned int> {
+					_OFFSET(092) = 0x244E18;
+					_OFFSET(093rc1) = 0x23A298;
+				};
+
+				struct objectNumber : Variable<int> {
+					_OFFSET(092) = 0x244E08;
+					_OFFSET(093rc1) = 0x13078C;
+				};
+
+				struct writeOffset : Variable<unsigned int> {
+					_OFFSET(092) = 0x244E10;
+					_OFFSET(093rc1) = 0x23A23C;
+				};
+			};
+
+			struct currentID : Variable<int> {
+				_OFFSET(092) = 0x244E14;
+				_OFFSET(093rc1) = 0x23A290;
+			};
+		};
+
+	}
+}
+
+#undef _OFFSET

--- a/exedit/variables_core.hpp
+++ b/exedit/variables_core.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+namespace ExEdit {
+	namespace Variables {
+
+		template <typename T, bool IsArray = false>
+		struct Variable {
+			using type = T;
+			static inline constexpr bool isArray = IsArray;
+			using reference_type = T*;
+		};
+
+		template <typename T, bool IsArray>
+		struct Variable<T[], IsArray> {
+			using type = T[];
+			static inline constexpr bool isArray = IsArray;
+			using reference_type = T**;
+		};
+
+		template <typename Variable>
+		constexpr Variable::reference_type get092(const unsigned int exedit_base) {
+			return reinterpret_cast<Variable::reference_type>(exedit_base + Variable::offset092);
+		}
+
+		template <typename Variable>
+		constexpr Variable::reference_type get093rc1(const unsigned int exedit_base) {
+			return reinterpret_cast<Variable::reference_type>(exedit_base + Variable::offset093rc1);
+		}
+
+	}
+}


### PR DESCRIPTION
本リクエストでは、拡張編集の内部変数の情報（型とオフセットアドレス）をSDKに含めることを提案します。これにより、SDKとしての機能性が向上するのみならず、現状では各々のプロジェクトに分散している解析情報を本リポジトリに集約する効果が期待されます。

添付されているコードは設計の一案であり、試験的にAulsメモリ参照に含まれる変数情報を記載しています。想定される使用例は以下の通りです。

```C++
// 拡張編集 version0.92 のみに対応する例

#include <exedit.hpp>

extern unsigned int g_exedit_base;

void foo() {
	const auto objs = *ExEdit::Variables::get092<ExEdit::Variables::objectTable>(g_exedit_base);
	const auto n = *ExEdit::Variables::get092<ExEdit::Variables::objectTable::length>(g_exedit_base);

	// ...
}
```

```C++
// 拡張編集 version0.92 および 0.93rc1 に対応する例

#include <exedit.hpp>

extern unsigned int g_exedit_base;
extern ExEditVersion g_exedit_version;

template<typename Variable>
Variable::reference_type get_variable() {
	if (g_exedit_version == ExEditVersion::version092) {
		return ExEdit::Variables::get092<Variable>(g_exedit_base);
	}
	else if (g_exedit_version == ExEditVersion::version093rc1) {
		return ExEdit::Variables::get093rc1<Variable>(g_exedit_base);
	}
	else {
		return nullptr;
	}
}

void foo() {
	const auto objs = *get_variable<ExEdit::Variables::objectTable>();
	
	// この行はコンパイル不可（0.93rc1のオフセット情報が存在しないため）
	// const auto n = *get_variable<ExEdit::Variables::objectTable::length>();

	// ...
}
```

ご検討のほどよろしくお願い致します。